### PR TITLE
调整CodeCompare自适应布局

### DIFF
--- a/docs/.vitepress/theme/components/CodeCompare.vue
+++ b/docs/.vitepress/theme/components/CodeCompare.vue
@@ -69,6 +69,8 @@ defineProps({
   border: 1px solid var(--vp-c-divider);
   background-color: var(--vp-c-bg-soft);
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .pane-header {
@@ -92,9 +94,15 @@ defineProps({
   color: #349d6e;
 }
 
+.pane-content{
+  flex: 100%;
+  display: flex;
+}
 /* 调整插槽内代码块的 margin，使其贴合容器 */
 .pane-content :deep(div[class*='language-']) {
   margin: 0 !important;
   border-radius: 0 !important;
+  display: flex;
+  flex: 100%;
 }
 </style>


### PR DESCRIPTION
# 修改前
<img width="636" height="324" alt="old" src="https://github.com/user-attachments/assets/640decce-4104-4fa3-9aaf-e38b8fec5223" />  

# 修改后

<img width="636" height="330" alt="new" src="https://github.com/user-attachments/assets/4b0db370-4ac1-4dfe-b66b-b922e0cebdf5" />

<details>
<summary>不影响垂直布局/手机端</summary>
<img width="371" height="634" alt="v" src="https://github.com/user-attachments/assets/d45212c4-e285-4062-95f0-9755bcce6ab2" />   
  
flex享受者来了(
</details>